### PR TITLE
Import functions and classes from kernels subpackage

### DIFF
--- a/src/torchdet/kernels/__init__.py
+++ b/src/torchdet/kernels/__init__.py
@@ -1,0 +1,37 @@
+"""Kernels subpackage."""
+
+from .benchmark import nn_benchmark, func_benchmark
+from .avg_pool import AvgPoolLoop, BatchDimLoop, avg_pool_loop
+from .conv import ConvLoop, convolution_loop
+from .scatter import ScatterLoop, ScatterDimLoop, scatter_loop
+from .scatter_reduce import ScatterReduceLoop, ScatterReduceDimLoop, scatter_reduce_loop
+from .gather import GatherLoop, GatherDimLoop, gather_loop
+from .index_add import IndexAddLoop, IndexAddDimLoop, index_add_loop
+from .index_copy import index_copy_loop
+from .index_put import IndexPutLoop, IndexPutDimLoop, index_put_loop
+
+__all__ = [
+    "nn_benchmark",
+    "func_benchmark",
+    "AvgPoolLoop",
+    "BatchDimLoop",
+    "avg_pool_loop",
+    "ConvLoop",
+    "convolution_loop",
+    "ScatterLoop",
+    "ScatterDimLoop",
+    "scatter_loop",
+    "ScatterReduceLoop",
+    "ScatterReduceDimLoop",
+    "scatter_reduce_loop",
+    "GatherLoop",
+    "GatherDimLoop",
+    "gather_loop",
+    "IndexAddLoop",
+    "IndexAddDimLoop",
+    "index_add_loop",
+    "index_copy_loop",
+    "IndexPutLoop",
+    "IndexPutDimLoop",
+    "index_put_loop"
+]


### PR DESCRIPTION
This adds various functions and classes to the `kernels/__init__.py` so the kernels directory can be imported as a subpackage. Only one line is needed such as `import kernels` to get access to these functions and classes instead of having multiple lines to import each item. As an example, for Python files inside of `src/torchdet/` you can do:

```python
from . import kernels

avg_pool_params = kernels.AvgPoolLoop(...)
kernels.nn_benchmark(...)
```

Instead of:

```python
from .kernels.avg_pool import AvgPoolLoop
from .kernels.benchmark import nn_benchmark

avg_pool_params = AvgPoolLoop(...)
nn_benchmark(...)
```